### PR TITLE
feat：支持点击以隐藏词典名称

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import PluginState from './utils/PluginState'
 const PLAY_VOICE_COMMAND = 'qwerty-learner.playVoice'
 const PREV_WORD_COMMAND = 'qwerty-learner.prevWord'
 const NEXT_WORD_COMMAND = 'qwerty-learner.nextWord'
+const TOGGLE_DIC_NAME_COMMAND= 'qwerty-learner.toggleDicName'
 
 export function activate(context: vscode.ExtensionContext) {
   const pluginState = new PluginState(context)
@@ -27,6 +28,8 @@ export function activate(context: vscode.ExtensionContext) {
   nextWord.command = NEXT_WORD_COMMAND
   transBar.command = PLAY_VOICE_COMMAND
   transBar.tooltip = '播放发音'
+  wordBar.command = TOGGLE_DIC_NAME_COMMAND
+  wordBar.tooltip = '隐藏/显示字典名称'
 
   vscode.workspace.onDidChangeTextDocument((e) => {
     if (!pluginState.isStart) {
@@ -142,6 +145,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
       }),
       vscode.commands.registerCommand(PLAY_VOICE_COMMAND, playVoice),
+      vscode.commands.registerCommand(TOGGLE_DIC_NAME_COMMAND, toggleDicName),
       vscode.commands.registerCommand(PREV_WORD_COMMAND, () => {
         pluginState.prevWord()
         initializeBar()
@@ -149,6 +153,10 @@ export function activate(context: vscode.ExtensionContext) {
       vscode.commands.registerCommand(NEXT_WORD_COMMAND, () => {
         pluginState.nextWord()
         initializeBar()
+      }),
+      vscode.commands.registerCommand('TOGGLE_DIC_NAME_COMMAND', () => {
+        pluginState.toggleDicName()
+        initializeBar();
       }),
       vscode.commands.registerCommand('qwerty-learner.toggleChapterCycleMode', () => {
         pluginState.chapterCycleMode = !pluginState.chapterCycleMode
@@ -165,6 +173,10 @@ export function activate(context: vscode.ExtensionContext) {
     setUpWordBar()
     setUpTransBar()
     setUpInputBar()
+  }
+  function toggleDicName() {
+    pluginState.hideDicName = !pluginState.hideDicName;
+    wordBar.text = pluginState.getInitialWordBarContent(); 
   }
   function playVoice() {
     if (pluginState.shouldPlayVoice) {

--- a/src/utils/PluginState.ts
+++ b/src/utils/PluginState.ts
@@ -11,6 +11,7 @@ export default class PluginState {
   private _dictKey: string
   private dictWords: Word[]
   public dict: DictionaryResource
+  public hideDicName = false
 
   public chapterLength: number
   private _readOnlyMode: boolean
@@ -218,9 +219,13 @@ export default class PluginState {
     }
     this.currentExerciseCount = 0
   }
+  toggleDicName(){
+    this.hideDicName = !this.hideDicName;
+  }
 
   getInitialWordBarContent() {
-    return `${this.dict.name} chp.${this.chapter + 1}  ${this.order + 1}/${this.wordList.length}  ${
+    const name = this.hideDicName ? '' : this.dict.name;
+    return `${name} chp.${this.chapter + 1}  ${this.order + 1}/${this.wordList.length}  ${
       this.wordVisibility ? this.currentWord.name : ''
     }`
   }


### PR DESCRIPTION
为了使得此款插件的隐蔽性更好，我添加了隐藏词典名称的功能。以下是展示
点击前：
![image](https://github.com/RealKai42/qwerty-learner-vscode/assets/101414955/37fcecf2-ea70-4dae-b177-fa0d84ddd8ba)
鼠标悬停时：
![image](https://github.com/RealKai42/qwerty-learner-vscode/assets/101414955/5074dfed-a14e-4cfc-a0f6-a53b37b46b3e)

点击后：
![image](https://github.com/RealKai42/qwerty-learner-vscode/assets/101414955/28044054-6358-4108-bf37-d77c0f0099df)
