### PR TITLE
update: Allow inputing in editor when readonly mode is enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,10 @@ export function activate(context: vscode.ExtensionContext) {
       return
     }
 
+    if (pluginState.readOnlyMode) {
+      return
+    }
+
     const { uri } = e.document
     // 避免破坏配置文件
     if (uri.scheme.indexOf('vscode') !== -1) {


### PR DESCRIPTION
Currently, users cannot input in editor when readonly is enabled or not. I'm not sure if it's a bug or expected behavior. Generally, users would want to code at the same time when they enable readonly mode.