### PR TITLE
feat:监听输入，当最新输入与目标单词匹配则自动跳到下一词，可以基本实现背单词和写代码兼容

### DIFF
--- a/assets/dicts/GRE_3_T.json
+++ b/assets/dicts/GRE_3_T.json
@@ -2201,7 +2201,7 @@
     {
         "name": "cliche",
         "trans": [
-            "陈腐的usedsooftenthatithasbecomestaleormeaningless)",
+            "陈腐的",
             "陈词滥调"
         ],
         "usphone": "",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,10 @@
       {
         "command": "qwerty-learner.toggleChapterCycleMode",
         "title": "Qwerty Learner Change chapter Cycle Mode"
+      },
+      {
+        "command": "qwerty-learner.toggleAutoCaptureMode",
+        "title": "Qwerty Learner Auto Capture Mode"
       }
     ],
     "keybindings": [
@@ -82,6 +86,12 @@
         "command": "qwerty-learner.toggleChapterCycleMode",
         "key": "shift+alt+c",
         "mac": "ctrl+shift+c",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "qwerty-learner.toggleAutoCaptureMode",
+        "key": "shift+alt+v",
+        "mac": "ctrl+shift+v",
         "when": "editorTextFocus"
       }
     ],

--- a/src/utils/PluginState.ts
+++ b/src/utils/PluginState.ts
@@ -26,6 +26,7 @@ export default class PluginState {
   public hasWrong: boolean
   private curInput: string
   public chapterCycleMode: boolean
+  public autoCaptureMode: boolean
 
   public voiceLock: boolean
 
@@ -57,6 +58,8 @@ export default class PluginState {
     this.readOnlyIntervalId = null
     this.placeholder = getConfig('placeholder') // 用于控制word不可见时，inputBar中是否出现占位符及样式
     this.chapterCycleMode = false
+
+    this.autoCaptureMode = false
 
     this._wordVisibility = globalState.get('wordVisibility', true)
 


### PR DESCRIPTION
因为开着这个扩展就不能写代码了，所以我想可以增加一个配置，如果我正好输入候选单词则扩展删掉我这个相匹配的输入并跳到下一个词，如果我的输入与候选单词不一致则扩展不对我的输入进行操作。
所以增加了一个自动捕获模式autoCaptureMode，可以使用快捷键 "shift+alt+v"/ "ctrl+shift+v"开启。
实现还比较粗糙，单词必须一次性完整正确输入才会匹配并删除。
